### PR TITLE
Revert "argument as env"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,4 +26,5 @@ FROM scratch
 #scratch
 COPY --from=certs /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 COPY --from=builder /go/bin/caddy /usr/bin/caddy
-ENTRYPOINT ["/usr/bin/caddy", "run", "${CADDY_ARGS}"]
+ENTRYPOINT ["/usr/bin/caddy", "run"]
+


### PR DESCRIPTION
This reverts commit 9cf9376c92c7aee706f80bf494cf6ba72dd0a9e4 and makes kitcaddy work again.