### PR TITLE
Need two containerPorts that are called the same

### DIFF
--- a/helm/kitcaddy/templates/kitcaddy-deployment.yaml
+++ b/helm/kitcaddy/templates/kitcaddy-deployment.yaml
@@ -100,6 +100,10 @@ spec:
           - name: {{ $name }}
             containerPort: {{ $port }}
           {{- end }}
+          {{- range .Values.kitcaddy.extraPortsList }}
+          - containerPort: {{ .port }}
+            name: {{ .name }}
+          {{- end }}
           {{- if (.Values.sidecar.extraVolumeMounts) }}
           volumeMounts:
           {{- end }}
@@ -146,6 +150,10 @@ spec:
             {{- range $key, $value := .Values.kitcaddy.extraPorts }}
             - containerPort: {{ $value }}
               name: {{ $key }}
+            {{- end }}
+            {{- range .Values.kitcaddy.extraPortsList }}
+            - containerPort: {{ .port }}
+              name: {{ .name }}
             {{- end }}
           resources:
             {{- toYaml .Values.kitcaddy.resources | nindent 12 }}
@@ -206,6 +214,10 @@ spec:
             {{- range $name, $port := .Values.deployment.extraPorts }}
             - name: {{ $name }}
               containerPort: {{ $port }}
+            {{- end }}
+            {{- range .Values.kitcaddy.extraPortsList }}
+            - containerPort: {{ .port }}
+              name: {{ .name }}
             {{- end }}
           volumeMounts:
             - mountPath: /tmp


### PR DESCRIPTION
**Tanker om løsning:**
Den eksisterende extraPorts er et map, hvilket ikke understøtter at der er to porte der hedder det samme - De vil bare overskrive hinanden.

Jeg ved at kitcaddy chartet bruges rigtig mange steder, og jeg vil gerne undgå at lave breaking-changes. Jeg har derfor lavet en extraportsList, istedet for at ændre i den eksisterende extraPorts. 

**Baggrund:**
Netic har krav om at alle porte der skal kunne udstilles til internettet, hedder "http".

_Min case:_
Jeg har følgende url'er som alle peger på den samme servic (vdx-booking)e, på forskellige porte
- booking.vconf-stage.dk peger på port 7070
- booking.vconf-stage.dk/sms peger på port 7072
- booking.vconf-stage.dk/audit peger på port 7073
- booking.vconf-stage.dk/borgerrettet peger på port 7074
- booking.vconf-stage.dk/getsessiondata peger på port 8080
- booking.vconf-stage.dk/booking peger på port 8080
- booking-status.vconf-stage.dk peger på port 7071

Servicen har følgende mapping
- 7070 => containerPort 7070
- 7071 => containerPort 7071
- 7072 => containerPort 7072
- 7073 => containerPort 7073
- 7074 => containerPort 7074
- 8080 => containerPort 80


Alle disse porte skal hedde http for at contour kan finde ud af at lede traffik derhen