### PR TITLE
add kit-volume when nonroot

### DIFF
--- a/helm/kitcaddy/templates/doc-deployment.yaml
+++ b/helm/kitcaddy/templates/doc-deployment.yaml
@@ -72,4 +72,10 @@ spec:
           {{- end }}
           resources:
             {{- toYaml .Values.docDeployment.resources | nindent 12 }}
+          volumeMounts:
+            - name: kit-volume
+              mountPath: /kit
+      volumes:
+        - name: kit-volume
+          emptyDir: {}
 {{- end -}}


### PR DESCRIPTION
I dockerfilen på f.eks. medcom-video-api, kalder den scriptet config.sh
https://github.com/KvalitetsIT/medcom-video-api/blob/master/documentation/docker/config/config.sh

Dette script forsøger at oprette nogle filer i /kit - Og når den kører nonroot (og med readonlyfilesystem sat til **false**) får man fejlene:
```
kubectl logs -n vdx deploy/vdx-videoapi-documentation
Running set version
Add Dev version to list of versions
/kit/setVersion.sh: line 15: can't create /kit/env: Permission denied
Release version
Creating file with version and path
/kit/setVersion.sh: line 35: can't create /kit/env.tmp: Permission denied
cat: can't open '/kit/env': No such file or directory
mv: can't rename '/kit/env.tmp': No such file or directory
/kit/setVersion.sh: line 35: can't create /kit/env.tmp: Permission denied
cat: can't open '/kit/env': No such file or directory
mv: can't rename '/kit/env.tmp': No such file or directory
/kit/setVersion.sh: line 35: can't create /kit/env.tmp: Permission denied
cat: can't open '/kit/env': No such file or directory
mv: can't rename '/kit/env.tmp': No such file or directory
/kit/setVersion.sh: line 35: can't create /kit/env.tmp: Permission denied
cat: can't open '/kit/env': No such file or directory
mv: can't rename '/kit/env.tmp': No such file or directory
/kit/setVersion.sh: line 35: can't create /kit/env.tmp: Permission denied
cat: can't open '/kit/env': No such file or directory
mv: can't rename '/kit/env.tmp': No such file or directory
/kit/setVersion.sh: line 35: can't create /kit/env.tmp: Permission denied
cat: can't open '/kit/env': No such file or directory
mv: can't rename '/kit/env.tmp': No such file or directory
/kit/setVersion.sh: line 35: can't create /kit/env.tmp: Permission denied
cat: can't open '/kit/env': No such file or directory
mv: can't rename '/kit/env.tmp': No such file or directory
/kit/setVersion.sh: line 35: can't create /kit/env.tmp: Permission denied
cat: can't open '/kit/env': No such file or directory
mv: can't rename '/kit/env.tmp': No such file or directory
/kit/setVersion.sh: line 35: can't create /kit/env.tmp: Permission denied
cat: can't open '/kit/env': No such file or directory
mv: can't rename '/kit/env.tmp': No such file or directory
/kit/setVersion.sh: line 35: can't create /kit/env.tmp: Permission denied
cat: can't open '/kit/env': No such file or directory
mv: can't rename '/kit/env.tmp': No such file or directory
/kit/setVersion.sh: line 35: can't create /kit/env.tmp: Permission denied
cat: can't open '/kit/env': No such file or directory
mv: can't rename '/kit/env.tmp': No such file or directory
/kit/setVersion.sh: line 35: can't create /kit/env.tmp: Permission denied
cat: can't open '/kit/env': No such file or directory
mv: can't rename '/kit/env.tmp': No such file or directory
/kit/setVersion.sh: line 35: can't create /kit/env.tmp: Permission denied
cat: can't open '/kit/env': No such file or directory
mv: can't rename '/kit/env.tmp': No such file or directory
/kit/setVersion.sh: line 35: can't create /kit/env.tmp: Permission denied
cat: can't open '/kit/env': No such file or directory
mv: can't rename '/kit/env.tmp': No such file or directory
/kit/setVersion.sh: line 35: can't create /kit/env.tmp: Permission denied
cat: can't open '/kit/env': No such file or directory
mv: can't rename '/kit/env.tmp': No such file or directory
/kit/setVersion.sh: line 35: can't create /kit/env.tmp: Permission denied
```


Jeg vælger at hardcode den, eftersom det også er /kit der bruges i kithugs
https://github.com/KvalitetsIT/kithugs/blob/main/documentation/docker/config/config.sh