### PR TITLE
add xforwardedProto -header

### DIFF
--- a/helm/kitcaddy/templates/caddy.tpl
+++ b/helm/kitcaddy/templates/caddy.tpl
@@ -177,12 +177,17 @@
         "dial": "{{ .upstream.host }}:{{ .upstream.port }}"
       }
     ]
-    {{- if (.wsc) }}
+    {{- if or (.wsc) .upstream.xForwardedProto }}
     ,
     "headers": {
       "request": {
         "set": {
+          {{- if .upstream.xForwardedProto }}
+          "X-Forwarded-Proto": ["{{ .upstream.xForwardedProto }}"],
+          {{- end }}
+          {{- if (.wsc) }}
           "Host": ["{{ .upstream.host }}:{{ .upstream.port }}"]
+          {{- end }}
         }
       }
     }

--- a/helm/kitcaddyExampleValues.yaml
+++ b/helm/kitcaddyExampleValues.yaml
@@ -198,6 +198,7 @@ kitcaddy:
           upstream:
             host: localhost
             port: 8080
+            xForwardedProto: "https"
             clientTls:
               insecureSkipVerify: true
               clientCertificateFile: WSC_CLIENT_CERTIFICATE_FILE


### PR DESCRIPTION
Before adding the header:
![image](https://github.com/user-attachments/assets/65188f4d-53b9-4ae8-b5c0-b73cbe8da559)

After adding the header:
![image](https://github.com/user-attachments/assets/a7290489-d3cf-407d-98f1-84784bac4964)

The difference was the header 
```
"X-Forwarded-Proto\": [\"https\"]
```

So this PR will make it possible to set that header


This is needed in the new vdx-Netic environment, since the header is not automatically set by nginx anymore (they use envoy)